### PR TITLE
Fix: resolve multiple bugs related to loading in detail main session page

### DIFF
--- a/src/app/views/detail/session/main/detail-session-main.view.html
+++ b/src/app/views/detail/session/main/detail-session-main.view.html
@@ -1,4 +1,4 @@
-<div *ngIf="!isLoading && session && instance">
+<div *ngIf="session && instance">
     <div class="header-card">
         <mat-card style="width: 60vw; min-width: 60vw; border-left: 4px solid green"
                   [ngStyle]="{'border-left': session.exception?.type || session.exception?.message ? '4px solid red' : '4px solid green'}">
@@ -60,6 +60,9 @@
                 </div>
             </mat-card-title>
             <mat-card-content>
+                <div *ngIf="isLoading && session" style="display: flex; flex-direction: row; align-items: center; justify-content: center; font-style: italic; gap: 0.5em">
+                    <mat-progress-spinner  diameter="30" mode="indeterminate"></mat-progress-spinner> Chargement en cours...
+                </div>
                 <div style="display: flex; align-items: center;" *ngFor="let item of queryBySchema | keyvalue ">
                     <div style="display: flex; margin-right: 1em; margin-left: 1em;" *ngIf="item.key != 'null'">
                         <mat-icon class="material-symbols-outlined">Database</mat-icon>
@@ -90,7 +93,7 @@
             </mat-card-footer>
         </mat-card>
     </div>
-    <detail-session [session]="session" [instance]="instance"></detail-session>
+    <detail-session [session]="session" [completedSession]="completedSession" [instance]="instance"></detail-session>
 </div>
 
 <div *ngIf="!isLoading && !session && !instance" class="noDataMessage mat-elevation-z5" style="height: calc(100vh - 50px - 1em);">
@@ -99,6 +102,6 @@
     </h2>
 </div>
 
-<div *ngIf="isLoading" style="width: 100%; height: calc(100vh - 50px - 1em); display: flex; flex-direction: row; align-items: center; justify-content: center; font-style: italic; gap: 0.5em">
+<div *ngIf="isLoading && !session && !instance" style="width: 100%; height: calc(100vh - 50px - 1em); display: flex; flex-direction: row; align-items: center; justify-content: center; font-style: italic; gap: 0.5em">
     <mat-progress-spinner diameter="30" mode="indeterminate"></mat-progress-spinner> Chargement en cours...
 </div>

--- a/src/app/views/detail/session/rest/detail-session-rest.view.html
+++ b/src/app/views/detail/session/rest/detail-session-rest.view.html
@@ -12,7 +12,8 @@
                     {{ session.name || 'N/A' }}
                 </a>
                 <div class="right">
-                    <mat-progress-spinner *ngIf="!sessionParent" style="display:inline-flex !important;" diameter="30" mode="indeterminate"></mat-progress-spinner> 
+                    <mat-progress-spinner *ngIf="!sessionParent" style="display:inline-flex !important;" diameter="24" mode="indeterminate"
+                                          matTooltip="Chargement de l'appel parent" TooltipPosition="below"></mat-progress-spinner> 
                     <button mat-icon-button (click)="navigate($event,'parent')" matTooltip="Détail de l'appel parent"
                             [hidden]="!sessionParent">
                         <mat-icon>move_up</mat-icon>
@@ -71,7 +72,7 @@
                 </div>
             </mat-card-title>
             <mat-card-content>
-                <div *ngIf="!queryBySchema" style="display: flex; flex-direction: row; align-items: center; justify-content: center; font-style: italic; gap: 0.5em">
+                <div *ngIf="isLoading && session" style="display: flex; flex-direction: row; align-items: center; justify-content: center; font-style: italic; gap: 0.5em">
                     <mat-progress-spinner  diameter="30" mode="indeterminate"></mat-progress-spinner> Chargement en cours...
                 </div>
                 <div style="display: flex; align-items: center;" *ngFor="let item of queryBySchema | keyvalue ">


### PR DESCRIPTION

* Fix: resolve multiple bugs related to loading in detail session page
- cards are loaded independently as soon as data is received
- added a loading indicator when getting the parent of session
- added a loafing indicator when getting db info in instance cards

additional changes:
- fixed a bug where parent session is not set to default after navigation
- fixed a bug where db info showed in instance card is not set to default after navigation
- clean consoles / unused imports

* Fix:
- set same loading condition for main sessions page.
- fix uncorrect check in the loading of db info