### PR TITLE
Show database commands / improve detail timeline  

### DIFF
--- a/src/app/model/trace.model.ts
+++ b/src/app/model/trace.model.ts
@@ -101,6 +101,7 @@ export interface NamingRequest extends SessionStage<boolean> {
 }
 
 export interface DatabaseRequestStage extends RequestStage {
+    commands?: Array<string>;
     count?: Array<number>;
     order?: number;
 }
@@ -286,7 +287,7 @@ export class JdbcRequestNode implements Node<Label>, Link<Label> {
     formatLink(field: Label): string {
         switch (field) {
             case Label.ELAPSED_LATENSE: return `${this.nodeObject.end - this.nodeObject.start ? (this.nodeObject.end - this.nodeObject.start).toFixed(3)+"s": "?"}`
-            case Label.METHOD_RESOURCE: return getCommand(this.nodeObject?.commands, 'SQL ')// todo: with sql add schema
+            case Label.METHOD_RESOURCE: return `${this.nodeObject?.commands || '?'}`;
             case Label.SIZE_COMPRESSION: return this.nodeObject?.count < 0 ? '0': this.nodeObject?.count!= undefined? this.nodeObject?.count.toString() : '?'; // remove undefined condition 
             case Label.PROTOCOL_SCHEME: return "JDBC/Basic"
             case Label.STATUS_EXCEPTION: return this.nodeObject.exception && 'FAIL:' + this.nodeObject.exception?.type || 'OK'

--- a/src/app/shared/pipe/duration.pipe.ts
+++ b/src/app/shared/pipe/duration.pipe.ts
@@ -11,7 +11,7 @@ export class DurationPipe implements PipeTransform {
 
     transform(value: Period | number, ...args: any[]):string {
         let time = typeof value == "object" ? value.end - value.start : value;
-        if(!time){
+        if(!time && time !=0){
             return "?";
         }
         const remainingSeconds = this._decimalPipe.transform(Math.round((time % 60) * 1000) / 1000);

--- a/src/app/views/detail/database/detail-database.view.ts
+++ b/src/app/views/detail/database/detail-database.view.ts
@@ -110,7 +110,8 @@ export class DetailDatabaseView implements OnInit, OnDestroy {
             },
             groupTemplate: function(group){
                 let container = document.createElement('div');
-                let label = document.createElement('span');
+                if(group){
+                    let label = document.createElement('span');
                 label.innerHTML = group.content+ " ";
                 container.insertAdjacentElement('afterbegin',label);
                 container.insertAdjacentElement('beforeend', document.createElement('br'));
@@ -118,14 +119,17 @@ export class DetailDatabaseView implements OnInit, OnDestroy {
                     let count= document.createElement('span');
                     count.style.fontSize = 'smaller';
                     count.innerHTML = `count: ${group.count }`;
-                    container.insertAdjacentElement('beforeend', count);
+                    container.insertAdjacentElement('beforeend', count,);
+                } 
                 }
                 return container;
             }
         }
-        this.timeLine = new Timeline(this.timelineContainer.nativeElement,items);
-        this.timeLine.setOptions(options);
-        this.timeLine.setGroups(groups);
+        if (this.timeLine) {  // destroy if exists 
+            this.timeLine.destroy();
+        }
+        this.timeLine = new Timeline(this.timelineContainer.nativeElement,items,groups,options);
+
     }
 
     navigate(event: MouseEvent, targetType: string, extraParam?: string) {

--- a/src/app/views/detail/ftp/detail-ftp.view.html
+++ b/src/app/views/detail/ftp/detail-ftp.view.html
@@ -45,3 +45,14 @@
     <div #timeline id="timeline"></div>
 </div>
 
+
+
+<div *ngIf="!isLoading && !request" class="noDataMessage mat-elevation-z5" style="height: calc(100vh - 50px - 1em);">
+    <h2>
+        Aucun détail disponible ..
+    </h2>
+</div>
+<div *ngIf="isLoading" style="width: 100%; height: calc(100vh - 50px - 1em); display: flex; flex-direction: row; align-items: center; justify-content: center; font-style: italic; gap: 0.5em">
+    <mat-progress-spinner diameter="30" mode="indeterminate"></mat-progress-spinner> Chargement en cours...
+</div>
+

--- a/src/app/views/detail/ftp/detail-ftp.view.ts
+++ b/src/app/views/detail/ftp/detail-ftp.view.ts
@@ -69,12 +69,13 @@ export class DetailFtpView implements OnInit, OnDestroy {
         let timeline_start = Math.trunc(this.request.start * 1000);
         let timeline_end = Math.ceil(this.request.end * 1000);
 
-        let items = this.request.actions.map(a => {
+        let items = this.request.actions.map((a: FtpRequestStage, i:number) => {
             let item: DataItem = {
-                group: a.start,
+                group: `${i}`,
                 start: Math.trunc(a.start * 1000),
                 end: Math.trunc(a.end * 1000),
                 content: '',
+                className: "ftp",
                 title: `<span>${this.pipe.transform(new Date(a.start * 1000), 'HH:mm:ss.SSS')} - ${this.pipe.transform(new Date(a.end * 1000), 'HH:mm:ss.SSS')}</span> (${this.durationPipe.transform({start: a.start, end: a.end})})<br>
                         <h4>${a?.args ? a.args.join('</br>') : ''}</h4>`
             }
@@ -86,9 +87,14 @@ export class DetailFtpView implements OnInit, OnDestroy {
             return item;
         });
 
-        this.timeLine = new Timeline(this.timelineContainer.nativeElement, items, this.request.actions.map(a => ({ id: a.start, content: a?.name })), {
-            min: timeline_start,
-            max: timeline_end
+        this.timeLine = new Timeline(this.timelineContainer.nativeElement, items, this.request.actions.map((a: FtpRequestStage, i:number) => ({ id: i, content: a?.name })), {
+            start: timeline_start,
+            end: timeline_end,
+            selectable : false,
+            clickToUse: true,
+            tooltip: {
+                followMouse: true
+            }
         });
     }
 

--- a/src/app/views/detail/ftp/detail-ftp.view.ts
+++ b/src/app/views/detail/ftp/detail-ftp.view.ts
@@ -40,6 +40,7 @@ export class DetailFtpView implements OnInit, OnDestroy {
             next: ([params, data, queryParams]) => {
                 this.params = {idSession: params.id_session, idFtp: params.id_ftp,
                     typeSession: data.type, typeMain: params.type_main, env: queryParams.env || application.default_env};
+                this.request = null;
                 this.getRequest();
             }
         }));
@@ -77,17 +78,20 @@ export class DetailFtpView implements OnInit, OnDestroy {
                 content: '',
                 className: "ftp",
                 title: `<span>${this.pipe.transform(new Date(a.start * 1000), 'HH:mm:ss.SSS')} - ${this.pipe.transform(new Date(a.end * 1000), 'HH:mm:ss.SSS')}</span> (${this.durationPipe.transform({start: a.start, end: a.end})})<br>
-                        <h4>${a?.args ? a.args.join('</br>') : ''}</h4>`
+                        <span>${a?.args ? a.args.join('</br>') : ''}</span>`
             }
 
             item.type = item.end <= item.start ? 'point' : 'range';
             if (a.exception?.message || a.exception?.type) {
-                item.className = 'bdd-failed';
+                item.className += ' bdd-failed';
             }
             return item;
         });
 
-        this.timeLine = new Timeline(this.timelineContainer.nativeElement, items, this.request.actions.map((a: FtpRequestStage, i:number) => ({ id: i, content: a?.name })), {
+        if (this.timeLine) {  // destroy if exists 
+            this.timeLine.destroy();
+        }
+        this.timeLine = new Timeline(this.timelineContainer.nativeElement, items, this.request.actions.map((a: FtpRequestStage, i:number) => ({ id: i, content: a?.name  })), {
             start: timeline_start,
             end: timeline_end,
             selectable : false,

--- a/src/app/views/detail/ldap/detail-ldap.view.html
+++ b/src/app/views/detail/ldap/detail-ldap.view.html
@@ -45,7 +45,13 @@
     <div #timeline id="timeline"></div>
 </div>
 
+
+<div *ngIf="!isLoading && !request" class="noDataMessage mat-elevation-z5" style="height: calc(100vh - 50px - 1em);">
+    <h2>
+        Aucun détail disponible ..
+    </h2>
+</div>
+
 <div *ngIf="isLoading" style="width: 100%; height: calc(100vh - 50px - 1em); display: flex; flex-direction: row; align-items: center; justify-content: center; font-style: italic; gap: 0.5em">
     <mat-progress-spinner diameter="30" mode="indeterminate"></mat-progress-spinner> Chargement en cours...
 </div>
-

--- a/src/app/views/detail/ldap/detail-ldap.view.ts
+++ b/src/app/views/detail/ldap/detail-ldap.view.ts
@@ -39,7 +39,8 @@ export class DetailLdapView implements OnInit, OnDestroy {
             next: ([params, data, queryParams]) => {
                 this.params = {idSession: params.id_session, idLdap: params.id_ldap,
                     typeSession: data.type, typeMain: params.type_main, env: queryParams.env || application.default_env};
-                this.getRequest();
+                    this.request = null;
+                    this.getRequest();
             }
         }));
     }
@@ -76,7 +77,7 @@ export class DetailLdapView implements OnInit, OnDestroy {
                 content: '',
                 className: "ldap",
                 title: `<span>${this.pipe.transform(a.start * 1000, 'HH:mm:ss.SSS')} - ${this.pipe.transform(a.end * 1000, 'HH:mm:ss.SSS')}</span> (${this.durationPipe.transform({start: a.start, end: a.end})})<br>
-                        <h4>${a?.args ? a.args.join('</br>') : ''}</h4>`
+                        <span>${a?.args ? a.args.join('</br>') : ''}</span>`
             }
             item.type = item.end <= item.start ? 'point' : 'range';
             if (a.exception?.message || a.exception?.type) {
@@ -85,6 +86,9 @@ export class DetailLdapView implements OnInit, OnDestroy {
             return item;
         });
 
+        if (this.timeLine) {  // destroy if exists 
+            this.timeLine.destroy();
+        }
         this.timeLine = new Timeline(this.timelineContainer.nativeElement, items, this.request.actions.map((a:NamingRequestStage, i:number) => ({ id: i, content: a?.name })), {
             start: timeline_start,
             end: timeline_end,

--- a/src/app/views/detail/ldap/detail-ldap.view.ts
+++ b/src/app/views/detail/ldap/detail-ldap.view.ts
@@ -68,25 +68,31 @@ export class DetailLdapView implements OnInit, OnDestroy {
         let timeline_start = Math.trunc(this.request.start * 1000);
         let timeline_end = Math.ceil(this.request.end * 1000);
 
-        let items = this.request.actions.map(a => {
+        let items = this.request.actions.map((a: NamingRequestStage, i: number) => {
             let item: DataItem = {
-                group: a.start,
+                group: `${i}`,
                 start: Math.trunc(a.start * 1000),
                 end: Math.trunc(a.end * 1000),
                 content: '',
+                className: "ldap",
                 title: `<span>${this.pipe.transform(a.start * 1000, 'HH:mm:ss.SSS')} - ${this.pipe.transform(a.end * 1000, 'HH:mm:ss.SSS')}</span> (${this.durationPipe.transform({start: a.start, end: a.end})})<br>
                         <h4>${a?.args ? a.args.join('</br>') : ''}</h4>`
             }
             item.type = item.end <= item.start ? 'point' : 'range';
             if (a.exception?.message || a.exception?.type) {
-                item.className = 'bdd-failed';
+                item.className += ' bdd-failed';
             }
             return item;
         });
 
-        this.timeLine = new Timeline(this.timelineContainer.nativeElement, items, this.request.actions.map(a => ({ id: a.start, content: a?.name })), {
-            min: timeline_start,
-            max: timeline_end
+        this.timeLine = new Timeline(this.timelineContainer.nativeElement, items, this.request.actions.map((a:NamingRequestStage, i:number) => ({ id: i, content: a?.name })), {
+            start: timeline_start,
+            end: timeline_end,
+            selectable : false,
+            clickToUse: true,
+            tooltip: {
+                followMouse: true
+            }
         });
     }
 

--- a/src/app/views/detail/session/_component/database-table/detail-database-table.component.ts
+++ b/src/app/views/detail/session/_component/database-table/detail-database-table.component.ts
@@ -29,14 +29,12 @@ export class DetailDatabaseTableComponent implements OnInit {
         this.dataSource.sortingDataAccessor = sortingDataAccessor;
     }
 
-    getCommand(commands: string[]): string {
-        let command = "[--]";
-        if (commands?.length == 1) {
-            command = `[${commands[0]}]`
-        } else if (commands?.length > 1) {
-            command = "[SQL]"
+    getCommand(commands: string): string {
+        let command = "--";
+        if (commands) {
+            command = commands;
         }
-        return command;
+        return `[${command}]`;
     }
 
     selectedQuery(event: MouseEvent, row: number) {

--- a/src/app/views/detail/session/_component/ftp-table/detail-ftp-table.component.ts
+++ b/src/app/views/detail/session/_component/ftp-table/detail-ftp-table.component.ts
@@ -30,7 +30,6 @@ export class DetailFtpTableComponent implements OnInit {
     }
 
     selectedRequest(event: MouseEvent, row: any) {
-        console.log(row)
         this.onClickRow.emit({event: event, row: row});
     }
 }

--- a/src/app/views/detail/session/main/detail-session-main.view.html
+++ b/src/app/views/detail/session/main/detail-session-main.view.html
@@ -98,7 +98,7 @@
     <detail-session [session]="session" [completedSession]="completedSession" [instance]="instance"></detail-session>
 </div>
 
-<div *ngIf="!isLoading && !session && !instance" class="noDataMessage mat-elevation-z5" style="height: calc(100vh - 50px - 1em);">
+<div *ngIf="!isLoading && !session" class="noDataMessage mat-elevation-z5" style="height: calc(100vh - 50px - 1em);">
     <h2>
         Aucun détail disponible .. <br>
     </h2>

--- a/src/app/views/detail/session/rest/detail-session-rest.view.html
+++ b/src/app/views/detail/session/rest/detail-session-rest.view.html
@@ -12,10 +12,11 @@
                     {{ session.name || 'N/A' }}
                 </a>
                 <div class="right">        
-                    <mat-progress-spinner *ngIf="parentLoading && !sessionParent" style="display:inline-flex !important;" diameter="24" mode="indeterminate"
+                    <mat-progress-spinner [hidden]="sessionParent" *ngIf="parentLoading && !sessionParent" style="display:inline-flex !important;" diameter="24" mode="indeterminate"
                                           matTooltip="Chargement de l'appel parent" TooltipPosition="below"></mat-progress-spinner> 
                     <button mat-icon-button (click)="navigate($event,'parent')" matTooltip="Détail de l'appel parent"
-                            [hidden]="!sessionParent">
+                            [disabled]="!sessionParent"
+                            [hidden]="parentLoading">
                         <mat-icon>move_up</mat-icon>
                     </button>
                     <button mat-icon-button (click)="navigate($event,'tree')" matTooltip="Arbre d'appels">
@@ -110,7 +111,7 @@
     <detail-session [session]="session" [completedSession]="completedSession" [instance]="instance"></detail-session>
 </div>
 
-<div *ngIf="!isLoading && !session && !instance" class="noDataMessage mat-elevation-z5" style="height: calc(100vh - 50px - 1em);">
+<div *ngIf="!isLoading && !session" class="noDataMessage mat-elevation-z5" style="height: calc(100vh - 50px - 1em);">
     <h2>
         Aucun détail disponible .. <br>
     </h2>

--- a/src/app/views/detail/smtp/detail-smtp.view.html
+++ b/src/app/views/detail/smtp/detail-smtp.view.html
@@ -1,4 +1,4 @@
-<div *ngIf="!isLoading && request" class="header-card">
+<div *ngIf="request" class="header-card">
     <mat-card style="width: 100vw; min-width: 100vw;" [ngClass]="!exception ? 'success': 'fail'">
         <mat-card-title>
             <div style="display: flex; align-items: center; gap: 0.5em">
@@ -33,7 +33,7 @@
 </div>
 
 
-<div [hidden]="isLoading && !request" style="margin-bottom: 2em;">
+<div [hidden]="!request" style="margin-bottom: 2em;">
     <div style="display: flex; flex-direction: row; justify-content: center; align-items: center; align-content: center;">
         <mat-divider style="margin-right: 1em; flex: 1 1 0%"></mat-divider>
         <div style="display: flex; align-items: center; gap: 0.5em; margin-bottom:  0.5em; font-size: 20px; font-weight: 500;">
@@ -108,6 +108,12 @@
 </div>
 
 
+
+<div *ngIf="!isLoading && !request" class="noDataMessage mat-elevation-z5" style="height: calc(100vh - 50px - 1em);">
+    <h2>
+        Aucun détail disponible ..
+    </h2>
+</div>
 <div *ngIf="isLoading" style="width: 100%; height: calc(100vh - 50px - 1em); display: flex; flex-direction: row; align-items: center; justify-content: center; font-style: italic; gap: 0.5em">
     <mat-progress-spinner diameter="30" mode="indeterminate"></mat-progress-spinner> Chargement en cours...
 </div>

--- a/src/app/views/detail/smtp/detail-smtp.view.ts
+++ b/src/app/views/detail/smtp/detail-smtp.view.ts
@@ -43,6 +43,7 @@ export class DetailSmtpView implements OnInit, OnDestroy {
             next: ([params, data, queryParams]) => {
                 this.params = {idSession: params.id_session, idSmtp: params.id_smtp,
                     typeSession: data.type, typeMain: params.type_main, env: queryParams.env || application.default_env};
+                this.request = null;
                 this.getRequest();
             }
         }));
@@ -83,7 +84,7 @@ export class DetailSmtpView implements OnInit, OnDestroy {
                 end: Math.trunc(a.end * 1000),
                 content: '',
                 className: "smtp",
-                title: `<span>${this.pipe.transform(new Date(a.start * 1000), 'HH:mm:ss.SSS')} - ${this.pipe.transform(new Date(a.end * 1000), 'HH:mm:ss.SSS')}</span> (${this.durationPipe.transform({start: a.start, end: a.end})})<br>`
+                title: `<span>${this.pipe.transform(new Date(a.start * 1000), 'HH:mm:ss.SSS')} - ${this.pipe.transform(new Date(a.end * 1000), 'HH:mm:ss.SSS')}</span> (${this.durationPipe.transform({start: a.start, end: a.end})})`
             }
             item.type = item.end <= item.start ? 'point' : 'range';
             if (a?.exception?.message || a?.exception?.type) {
@@ -92,6 +93,9 @@ export class DetailSmtpView implements OnInit, OnDestroy {
             return item;
         });
 
+        if (this.timeLine) {  // destroy if exists 
+            this.timeLine.destroy();
+        }
         this.timeLine = new Timeline(this.timelineContainer.nativeElement, items, this.request.actions.map((a:MailRequestStage, i:number) => ({ id: i, content: a?.name })), {
             selectable : false,
             clickToUse: true,

--- a/src/app/views/detail/smtp/detail-smtp.view.ts
+++ b/src/app/views/detail/smtp/detail-smtp.view.ts
@@ -76,24 +76,28 @@ export class DetailSmtpView implements OnInit, OnDestroy {
         let timeline_end = Math.ceil(this.request.end * 1000);
         let actions = this.request.actions.sort((a, b) => a.order - b.order);
 
-        let items = this.request.actions.map(a => {
+        let items = this.request.actions.map((a:MailRequestStage, i:number) => {
             let item: DataItem = {
-                group: a.start,
+                group: `${i}`,
                 start: Math.trunc(a.start * 1000),
                 end: Math.trunc(a.end * 1000),
                 content: '',
+                className: "smtp",
                 title: `<span>${this.pipe.transform(new Date(a.start * 1000), 'HH:mm:ss.SSS')} - ${this.pipe.transform(new Date(a.end * 1000), 'HH:mm:ss.SSS')}</span> (${this.durationPipe.transform({start: a.start, end: a.end})})<br>`
             }
             item.type = item.end <= item.start ? 'point' : 'range';
             if (a?.exception?.message || a?.exception?.type) {
-                item.className = 'bdd-failed';
+                item.className += ' bdd-failed';
             }
             return item;
         });
 
-        this.timeLine = new Timeline(this.timelineContainer.nativeElement, items, this.request.actions.map(a => ({ id: a.start, content: a?.name })), {
-            min: timeline_start,
-            max: timeline_end
+        this.timeLine = new Timeline(this.timelineContainer.nativeElement, items, this.request.actions.map((a:MailRequestStage, i:number) => ({ id: i, content: a?.name })), {
+            selectable : false,
+            clickToUse: true,
+            tooltip: {
+                followMouse: true
+            }
         });
     }
 

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -102,34 +102,42 @@ mat-form-field.no-subscript {
 
 
 .vis-item {
-  border-color: #040730 !important;
   color:white !important;
   cursor: pointer !important;
 }
+.overflow .vis-item-overflow {
+    overflow: visible !important;
+    color:#000000 !important;
+}
 
 .vis-item.rest{
-  background-color: #3F51B5;
-  
+  background-color: #3F51B5; 
+  border-color: #3F51B5;
 }
 
 .vis-item.ftp{
   background-color: #2196F3;
+  border-color: #2196F3;
 
 }
 .vis-item.smtp{
   background-color: #9C27B0;
+  border-color: #9C27B0;
 
 }
 .vis-item.ldap{
   background-color: #00BCD4;
+  border-color: #00BCD4;
 
 }
 .vis-item.database{
   background-color: #4CAF50;
+  border-color: #4CAF50;
 
 }
 .vis-item.local{
   background-color: #3b3b38;
+  border-color: #3b3b38;
 
 }
 


### PR DESCRIPTION
Closes : #111 
changes done to database detail timeline: 
- distinct commands are now shown in the timeline 
- count value is show under the group  


additional changes : 
- adapted tree view to commands change in the trace model
- fixed a bug in duration pipe, where start - end returns '?' instead of  0
- added missing message for loading and nodata for each request detail page (ftp, database, smtp, ldap)
- fixed bug in request detail pages ( ftp, database, smtp, ldap) where value is not reset 
- added correct condition for showing nodata message in reset session detail and main session detail
- parent button is disabled when the parent request returns nothing
- changed the value used  for ID in timeline groups 
- set the correct color for each type of request in detail timeline 