### PR TITLE
feat: mettre à jour les dépendances jQuery et ajouter des filtres dans les vues de recherche

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,8 +22,8 @@
     "@angular/platform-browser-dynamic": "^16.2.12",
     "@angular/router": "^16.2.12",
     "@fortawesome/fontawesome-free": "^6.0.0",
-    "@oneteme/jquery-apexcharts": "^0.0.24",
-    "@oneteme/jquery-table": "^0.0.1",
+    "@oneteme/jquery-apexcharts": "^0.0.26",
+    "@oneteme/jquery-table": "^0.0.2",
     "moment": "^2.29.4",
     "moment-timezone": "^0.5.43",
     "mxgraph": "^4.2.2",
@@ -59,8 +59,5 @@
     "karma-jasmine-html-reporter": "^1.7.0",
     "mxgraph-type-definitions": "^1.0.6",
     "typescript": "~4.9.3"
-  },
-  "overrides": {
-    "@oneteme/jquery-core": "0.0.27"
   }
 }

--- a/src/app/views/search/main/search-main.view.html
+++ b/src/app/views/search/main/search-main.view.html
@@ -11,6 +11,38 @@
       <mat-datepicker-toggle matIconSuffix [for]="picker"></mat-datepicker-toggle>
       <mat-date-range-picker #picker></mat-date-range-picker>
     </mat-form-field>
+    <mat-form-field class="no-subscript" [class.loading]="serverNameIsLoading" appearance="outline">
+      <mat-label>Hôte</mat-label>
+      <mat-select [formControl]="serverFilterForm.controls.appname" multiple (selectionChange)="onChangeServer($event)">
+        <span *ngIf="serverNameIsLoading && queryParams.appname && queryParams.appname[0]!=''">
+          <mat-option *ngFor="let s of queryParams.appname" [value]="s">{{s}}</mat-option>
+        </span>
+        <mat-option *ngFor="let d of nameDataList" [value]="d">{{d}}</mat-option>
+      </mat-select>
+      <mat-spinner *ngIf="serverNameIsLoading" [diameter]="18"></mat-spinner>
+    </mat-form-field>
+    <mat-form-field style="width: 165px" class="no-subscript" appearance="outline">
+      <mat-label>Status</mat-label>
+      <mat-select [formControl]="serverFilterForm.controls.rangestatus" multiple (selectionChange)="onChangeStatus($event)">
+        <mat-select-trigger>
+          <div style="display: flex; gap: 0.5em; align-items: center">
+            <mat-icon [style.color]="serverFilterForm.controls.rangestatus.value?.[0]?.color">
+              {{serverFilterForm.controls.rangestatus.value?.[0]?.icon}}
+            </mat-icon>
+            {{serverFilterForm.controls.rangestatus.value?.[0]?.label || ''}}
+            <span *ngIf="(serverFilterForm.controls.rangestatus.value?.length || 0) > 1" class="additional-selection">
+              (+{{(serverFilterForm.controls.rangestatus.value?.length || 0) - 1}} {{serverFilterForm.controls.rangestatus.value.length === 2 ? 'autre' : 'autres'}})
+            </span>
+          </div>
+        </mat-select-trigger>
+        <mat-option *ngFor="let s of filters" [value]="s">
+          <div style="display: flex; align-content: center">
+            <mat-icon [style.color]="s.color">{{s.icon}}</mat-icon>
+            {{s.label}}
+          </div>
+        </mat-option>
+      </mat-select>
+    </mat-form-field>
     <button mat-mini-fab color="primary" (click)="search()">
       <mat-icon matSuffix>search</mat-icon>
     </button>

--- a/src/app/views/search/rest/search-rest.view.html
+++ b/src/app/views/search/rest/search-rest.view.html
@@ -11,6 +11,36 @@
       <mat-date-range-picker #picker></mat-date-range-picker>
     </mat-form-field>
     
+    <mat-form-field class="no-subscript" [class.loading]="serverNameIsLoading" appearance="outline">
+      <mat-label>Hôte</mat-label>
+      <mat-select [formControl]="serverFilterForm.controls.appname" multiple (selectionChange)="onChangeServer($event)">
+        <span *ngIf="serverNameIsLoading && queryParams.appname && queryParams.appname[0]!=''"><mat-option *ngFor="let s of queryParams.appname" [value]="s">{{s}}</mat-option></span>
+        <mat-option *ngFor="let d of nameDataList" [value]="d">{{d}}</mat-option>
+      </mat-select>
+      <mat-spinner *ngIf="serverNameIsLoading" [diameter]="18"></mat-spinner>
+    </mat-form-field>
+    <mat-form-field style="width: 165px" class="no-subscript" appearance="outline">
+      <mat-label>Status</mat-label>
+      <mat-select [formControl]="serverFilterForm.controls.rangestatus" multiple (selectionChange)="onChangeStatus($event)">
+        <mat-select-trigger>
+          <div style="display: flex; gap: 0.5em; align-items: center">
+            <mat-icon [style.color]="serverFilterForm.controls.rangestatus.value?.[0]?.color">
+              {{serverFilterForm.controls.rangestatus.value?.[0]?.icon}}
+            </mat-icon>
+            {{serverFilterForm.controls.rangestatus.value?.[0]?.label || ''}}
+            <span *ngIf="(serverFilterForm.controls.rangestatus.value?.length || 0) > 1" class="additional-selection">
+              (+{{(serverFilterForm.controls.rangestatus.value?.length || 0) - 1}} {{serverFilterForm.controls.rangestatus.value.length === 2 ? 'autre' : 'autres'}})
+            </span>
+          </div>
+        </mat-select-trigger>
+        <mat-option *ngFor="let s of filters" [value]="s">
+          <div style="display: flex; align-content: center">
+            <mat-icon [style.color]="s.color">{{s.icon}}</mat-icon>
+            {{s.label}}
+          </div>
+        </mat-option>
+      </mat-select>
+    </mat-form-field>
     <button mat-mini-fab color="primary"  (click)="search()">
       <mat-icon matSuffix>search</mat-icon>
     </button>


### PR DESCRIPTION
This pull request introduces enhancements to the search views by adding new filtering options for "Hôte" (Host) and "Status", as well as updating dependencies for improved stability and compatibility. It also removes an unnecessary package override.

**UI Enhancements:**

* Added a multi-select "Hôte" (Host) filter with loading state and spinner to both `search-main.view.html` and `search-rest.view.html`, allowing users to filter by host and see loading feedback. [[1]](diffhunk://#diff-4b18f87652c5310ddbeec6d77f7d6414f12c9f07edfaa450631892822fc514d7R14-R45) [[2]](diffhunk://#diff-f123d5c0a6dde8d12586d69d3c769ad97dd9e2565e97127951c72f91fcb421e7R14-R43)
* Added a multi-select "Status" filter with color-coded icons and summary of selected statuses, improving the user experience for filtering by status. [[1]](diffhunk://#diff-4b18f87652c5310ddbeec6d77f7d6414f12c9f07edfaa450631892822fc514d7R14-R45) [[2]](diffhunk://#diff-f123d5c0a6dde8d12586d69d3c769ad97dd9e2565e97127951c72f91fcb421e7R14-R43)

**Dependency Updates:**

* Updated `@oneteme/jquery-apexcharts` from version `0.0.24` to `0.0.26` and `@oneteme/jquery-table` from `0.0.1` to `0.0.2` in `package.json` for bug fixes and new features.

**Build Configuration:**

* Removed the `"overrides"` section for `@oneteme/jquery-core` from `package.json` as it is no longer necessary.