### PR TITLE
refactor: remove inactive protocols count and related UI elements fro…

### DIFF
--- a/src/app/views/dashboard/dashboard.component.html
+++ b/src/app/views/dashboard/dashboard.component.html
@@ -24,13 +24,6 @@
   <button (click)="showInactiveProtocols = true">Afficher quand même</button>
 </div>
 
-<!-- Banner : tous protocoles OK -->
-<div class="db-all-ok" *ngIf="!hasNoData && !kpiLoading && inactiveProtocolsCount === protocolDefs.length && !showInactiveProtocols">
-  <mat-icon class="material-symbols-outlined">check_circle</mat-icon>
-  <span>Aucun incident protocole sur la période sélectionnée</span>
-  <button (click)="showInactiveProtocols = true">Afficher l'activité</button>
-</div>
-
 <div class="db-grid">
   <!-- Colonne principale : liste des protocoles -->
   <section class="db-main">

--- a/src/app/views/dashboard/dashboard.component.ts
+++ b/src/app/views/dashboard/dashboard.component.ts
@@ -119,7 +119,6 @@ export class DashboardComponent implements OnDestroy {
     sessExcLineConfig = Constants.SESSION_EXCEPTION_LINE;
 
     // server health
-    inactiveProtocolsCount = 0;
     quietProtocols: typeof this.protocolDefs = [];
     stoppedServers: LastServerStart[] = [];
     unstableServers: LastServerStart[] = [];
@@ -442,7 +441,6 @@ export class DashboardComponent implements OnDestroy {
 
     private _rebuildServerHealth(): void {
         const keys = ['restRequestExceptionsTable', 'databaseRequestExceptionsTable', 'ftpRequestExceptionsTable', 'smtpRequestExceptionsTable', 'ldapRequestExceptionsTable'];
-        this.inactiveProtocolsCount = keys.filter(k => !this.chartRequests[k]?.isLoading && !this.chartRequests[k]?.data?.length).length;
         this.quietProtocols = this.protocolDefs.filter(p =>
             !this.chartRequests[p.reqKey].isLoading &&
             !this.chartRequests[p.reqKey].data?.length


### PR DESCRIPTION
This pull request simplifies the logic for displaying protocol health status on the dashboard by removing the unused `inactiveProtocolsCount` property and its associated conditional rendering. The changes focus on cleaning up both the component's TypeScript logic and the corresponding HTML template.

Dashboard protocol health display cleanup:

* Removed the `inactiveProtocolsCount` property from the `DashboardComponent` class and eliminated its calculation in the `_rebuildServerHealth` method, as it is no longer used for display logic. [[1]](diffhunk://#diff-17ccb1e22d4877e6679c9649d0202963a037060205f12cda524d1b500f38893eL122) [[2]](diffhunk://#diff-17ccb1e22d4877e6679c9649d0202963a037060205f12cda524d1b500f38893eL445)
* Deleted the "all protocols OK" banner from the dashboard template, streamlining the user interface and relying on other mechanisms to indicate protocol status.